### PR TITLE
Support multiple versions of julia

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         version:
           - '1.6'
+          - '1.7'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/benchmark.jl
+++ b/benchmark.jl
@@ -2,13 +2,15 @@ using Test
 
 @testset "benchmark" begin 
     jupytext = Sys.which("jupytext")
+    major = VERSION.major
+    minor = VERSION.minor
 
     if isnothing(jupytext)
         jupytext = normpath(Conda.SCRIPTDIR, "jupytext") # e.g. ~/.julia/conda/3/bin/jupytext
     end
 
-    t_naive = @elapsed run(`$jupytext --to ipynb --execute testout_naive.jl`)
-    t_sys = @elapsed run(`$jupytext --to ipynb --execute testout_sys.jl`)
+    t_naive = @elapsed run(`$jupytext --execute --to ipynb --set-kernel julia-$(major).$(minor) testout_naive.jl`)
+    t_sys = @elapsed run(`$jupytext --execute --to ipynb --set-kernel julia-sys-$(major).$(minor) testout_sys.jl`)
     @show t_naive
     @show t_sys
     @test t_naive > t_sys

--- a/executenb.jl
+++ b/executenb.jl
@@ -6,4 +6,6 @@ if isnothing(jupytext)
     jupytext = normpath(Conda.SCRIPTDIR, "jupytext") # e.g. ~/.julia/conda/3/bin/jupytext
 end
 
-run(`$jupytext --to ipynb --execute nb.jl`)
+major = VERSION.major
+minor = VERSION.minor
+run(`$(jupytext) --execute --to ipynb --set-kernel julia-trace-$(major).$(minor) nb.jl`)

--- a/nb.jl
+++ b/nb.jl
@@ -7,11 +7,11 @@
 #       extension: .jl
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.11.1
+#       jupytext_version: 1.13.4
 #   kernelspec:
-#     display_name: Julia-trace 1.6.0
+#     display_name: Julia-trace 1.7.1
 #     language: julia
-#     name: julia-trace-1.6
+#     name: julia-trace-1.7
 # ---
 
 # +


### PR DESCRIPTION
This PR makes sysimage_creator support Julia >= 1.6. (Currently we only support for Julia 1.6)
By using `--set-kernel <kernel-name e.g. julia-1.6>`, we can call `jupytext --execute nb.jl` for various julia on the fly.