### PR TITLE
Modify path to sys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test:
 
 clean:
 	-rm -f tmp*
-	-rm -f sys*
+	julia -e 'rm(joinpath(pwd(), "v$$(VERSION.major).$$(VERSION.minor)"), recursive=true, force=true)'
 	-rm -f traced_nb.jl traced_runtests.jl
 	-rm -f *.ipynb
 	-rm -f Manifest.toml

--- a/build.jl
+++ b/build.jl
@@ -1,13 +1,15 @@
 using PackageCompiler
 using Libdl: dlext
 
+sysimage_path = joinpath(@__DIR__, "v$(major).$(minor)", "sys" * "." * Libdl.dlext)
+
 create_sysimage(
     [:StatsPlots, :Plots, :DataFrames], 
     precompile_statements_file=[
         "traced_runtests.jl", 
         "traced_nb.jl"
     ],
-    sysimage_path=joinpath(@__DIR__, "sys.$(dlext)"),
+    sysimage_path=sysimage_path,
     cpu_target = PackageCompiler.default_app_cpu_target()
 )
 

--- a/build.jl
+++ b/build.jl
@@ -1,5 +1,5 @@
 using PackageCompiler
-using Libdl: dlext
+using Libdl
 
 major = VERSION.major
 minor = VERSION.minor

--- a/build.jl
+++ b/build.jl
@@ -1,6 +1,9 @@
 using PackageCompiler
 using Libdl: dlext
 
+major = VERSION.major
+minor = VERSION.minor
+
 sysimage_path = joinpath(@__DIR__, "v$(major).$(minor)", "sys" * "." * Libdl.dlext)
 
 create_sysimage(

--- a/installkernel.jl
+++ b/installkernel.jl
@@ -8,7 +8,7 @@ major = VERSION.major
 minor = VERSION.minor
 
 sysimage_path = joinpath(@__DIR__, "v$(major).$(minor)", "sys" * "." * Libdl.dlext)
-mkpath(dirname(sysimage))
+mkpath(dirname(sysimage_path))
 
 installkernel(
     "Julia-sys",

--- a/installkernel.jl
+++ b/installkernel.jl
@@ -4,7 +4,11 @@ using Libdl
 # This kernel will be removed via removekernel.jl
 installkernel("Julia-trace", "--project=@.", "--trace-compile=traced_nb.jl")
 
-sysimage = joinpath(@__DIR__, "sys" * "." * Libdl.dlext)
+major = VERSION.major
+minor = VERSION.minor
+
+sysimage = joinpath(@__DIR__, "v$(major).$(minor)", "sys" * "." * Libdl.dlext)
+mkpath(sysimage)
 
 installkernel(
     "Julia-sys",

--- a/installkernel.jl
+++ b/installkernel.jl
@@ -7,19 +7,19 @@ installkernel("Julia-trace", "--project=@.", "--trace-compile=traced_nb.jl")
 major = VERSION.major
 minor = VERSION.minor
 
-sysimage = joinpath(@__DIR__, "v$(major).$(minor)", "sys" * "." * Libdl.dlext)
-mkpath(sysimage)
+sysimage_path = joinpath(@__DIR__, "v$(major).$(minor)", "sys" * "." * Libdl.dlext)
+mkpath(dirname(sysimage))
 
 installkernel(
     "Julia-sys",
-    "--project=@.", "--sysimage=$(sysimage)"
+    "--project=@.", "--sysimage=$(sysimage_path)"
 )
 
 nthreads = Sys.CPU_THREADS
 
 installkernel(
     "julia-sys-$(nthreads)-threads",
-    "--project=@.", "--sysimage=$(sysimage)",
+    "--project=@.", "--sysimage=$(sysimage_path)",
     env=Dict(
         "JULIA_NUM_THREADS"=>"$(nthreads)",
     ),


### PR DESCRIPTION
If you use julia 1.6, the sysimage `sys.$(dlext)` is generated at `v1.6/sys.$(dlext)`
If you use julia 1.7, the sysimage `sys.$(dlext)` is generated at `v1.7/sys.$(dlext)`