### PR TITLE
add a magic option

### DIFF
--- a/build.jl
+++ b/build.jl
@@ -12,6 +12,7 @@ create_sysimage(
         "traced_runtests.jl",
         "traced_nb.jl",
     ],
+    include_transitive_dependencies = false,
     sysimage_path=sysimage_path,
     cpu_target=PackageCompiler.default_app_cpu_target(),
 )


### PR DESCRIPTION
I'm not sure, but I think `include_transitive_dependencies = false` will prevent downloading MKL_jll for first time loading sysimage generated by our tool