### PR TITLE
use J not j

### DIFF
--- a/installkernel.jl
+++ b/installkernel.jl
@@ -18,7 +18,7 @@ installkernel(
 nthreads = Sys.CPU_THREADS
 
 installkernel(
-    "julia-sys-$(nthreads)-threads",
+    "Julia-sys-$(nthreads)-threads",
     "--project=@.", "--sysimage=$(sysimage_path)",
     env=Dict(
         "JULIA_NUM_THREADS" => "$(nthreads)",


### PR DESCRIPTION
There is inconsistency name convention for custom IJulia kernel.
We should've used `Julia` rather than `julia`.